### PR TITLE
use full path to load firmware.bin

### DIFF
--- a/python/ps4eye_init.py
+++ b/python/ps4eye_init.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import usb.core
 import usb.util
+import os
 import sys
 
 # check if initialized device already exists
@@ -31,7 +32,8 @@ def read_chunks(infile, chunk_size):
 chunk_size=512
 index=0x14
 value=0
-firmware=open("firmware.bin","rb")
+script_dir=os.path.abspath(os.path.dirname(__file__))
+firmware=open(script_dir + "/firmware.bin","rb")
 
 # transfer 512b chunks of the firmware
 for chunk in read_chunks(firmware, chunk_size):


### PR DESCRIPTION
Hi.

I tried to init ps4eye automatically via udev,
and I worried about the `ps4eye_init.py` can run only under `python` directory.
Using my modification, `ps4eye_init.py` can run from anywhere,
then I can initialize ps4eye automatically with following rules.

```
ACTION=="add",SUBSYSTEMS=="usb",ATTRS{idProduct}=="0580",ATTRS{idVendor}=="05a9",RUN+="/home/h-yaguchi/ps4eye/python/ps4eye_init.py"
SUBSYSTEMS=="usb",ATTRS{idProduct}=="058a",ATTRS{idVendor}=="05a9",MODE="666"
```

Regards.
